### PR TITLE
Column order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 env/
 .idea/
 .vagrant/
+dist/
+*.egg-info/
+venv/
+env/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -158,3 +158,21 @@ The fixture can then be loaded easily:
 ```shell
 ./manage.py loaddata myapp/fixtures/bend.json
 ```
+
+## Development and Testing
+
+To develop on django-bend:
+
+```
+git clone https://github.com/excellalabs/django-bend
+virtualenv venv
+. venv/bin/activate
+pip install -r requirements.txt
+```
+
+To run tests:
+
+```
+pip install -r requirements-test.txt
+py.test
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 setup(
     name="django_bend",
     description="Database dump conversion to Django fixtures",
-    version="0.0.4",
+    version="0.0.5",
     license="MIT",
     classifiers=[
         'License :: OSI Approved :: MIT License',
@@ -19,7 +19,7 @@ setup(
         'Framework :: Django :: 1.9',
     ],
     keywords='django fixture database dump',
-    packages=find_packages(),
+    packages=['django_bend'],
     install_requires=[
         'simplejson>=3.8.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',


### PR DESCRIPTION
@ath12 found a tricky bug:

If the columns defined in the mapping schema are not in the same order as they appear in the database dump, the bend process does NOT throw any errors BUT the values don't align correctly with the column titles.  For example, the resulting fixture may have a field labelled `username`, but the value may actually be `age`.

The problem was I was creating the list of "new column names" by iterating over the mapping schema.  Obviously, if the mapping schema isn't in the same order as the values, this results in a mismatch.  The following PR should resolve this issue.  I also created tests to validate.

Additional changes:

 - I also added tests to catch other edge cases where the schema and data dump do not align as expected
 - Added Python 3.6 to the travis tests
 - Adding guidance on how to execute the tests
 - Fix setup.py to no longer include the `tests` directory when pip installing